### PR TITLE
Enable multi-architecture image support for self-hosted GitHub Actions runners

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,34 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/github-runner:latest
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:24.04
+FROM --platform=$BUILDPLATFORM ubuntu:24.04
 
 ARG RUNNER_VERSION="2.322.0"
+ARG RUNNER_ARCH
 
 # Prevents installdependencies.sh from prompting the user and blocking the image creation
 ARG DEBIAN_FRONTEND=noninteractive
@@ -13,8 +14,8 @@ RUN apt install -y --no-install-recommends \
 RUN apt install -y libglib2.0-0t64 libnss3 libnspr4 libdbus-1-3 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libdrm2 libxcb1 libxkbcommon0 libatspi2.0-0t64 libx11-6 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2   
 
 RUN cd /home/docker && mkdir actions-runner && cd actions-runner \
-    && curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
-    && tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+    && curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz
 
 RUN chown -R docker /home/docker && /home/docker/actions-runner/bin/installdependencies.sh
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,80 @@ When running the docker image, or when executing docker compose, environment var
 Credit to [testdriven.io](https://testdriven.io/blog/github-actions-docker/) for the original start.sh script, which I slightly modified to make it work with a regular repository rather than with an enterprise. 
 
 Whene generating your GitHub PAT you will need to include `repo`, `workflow`, and `admin:org` permissions.
+
+## Multi-Architecture Support
+
+This repository now supports multi-architecture Docker image builds and deployments for GitHub Actions runners across both arm64 and amd64 environments.
+
+### Building Multi-Arch Images
+
+To build the multi-arch images, you can use the following command:
+
+```sh
+docker buildx build --platform linux/amd64,linux/arm64 -t <your-dockerhub-username>/github-runner:latest --push .
+```
+
+### Deploying Multi-Arch Images
+
+To deploy the multi-arch images, you can use the following command:
+
+```sh
+docker run -e REPO=<owner>/<repo> -e TOKEN=<your-github-personal-access-token> <your-dockerhub-username>/github-runner:latest
+```
+
+Alternatively, you can use `docker-compose` to deploy the multi-arch images:
+
+```yaml
+version: '3.8'
+
+services:
+  runner:
+    image: <your-dockerhub-username>/github-runner:latest
+    restart: unless-stopped
+    env_file: .env
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      mode: replicated
+      replicas: 4
+      resources:
+        reservations:
+          cpus: 0.5
+          memory: 1024M
+  cache:
+    image: ghcr.io/falcondev-oss/github-actions-cache-server:latest
+    restart: unless-stopped
+    ports:
+      - '3000:3000'
+    environment:
+      API_BASE_URL: http://cache:3000
+    volumes:
+      - cache:/app/.data
+
+volumes:
+  cache:
+```
+
+Make sure to replace `<your-dockerhub-username>` with your actual Docker Hub username.
+
+## Usage
+
+To use the GitHub Actions runner, you need to set the following environment variables:
+
+- `REPO`: The owner and repository name in the format `<owner>/<repo>`.
+- `TOKEN`: Your GitHub personal access token with `repo`, `workflow`, and `admin:org` permissions.
+
+You can set these environment variables in a `.env` file or pass them directly to the `docker run` command.
+
+Example `.env` file:
+
+```env
+REPO=owner/repo
+TOKEN=your-github-personal-access-token
+```
+
+Example `docker run` command:
+
+```sh
+docker run -e REPO=owner/repo -e TOKEN=your-github-personal-access-token <your-dockerhub-username>/github-runner:latest
+```


### PR DESCRIPTION
Add multi-architecture support for Docker image builds and deployments for GitHub Actions runners.

* **Dockerfile**
  - Add `--platform=$BUILDPLATFORM` to the `FROM` instruction.
  - Add `RUNNER_ARCH` argument to handle architecture-specific binaries.
  - Update the `curl` command to download the appropriate binary based on `RUNNER_ARCH`.

* **GitHub Actions Workflow**
  - Create a new workflow file `.github/workflows/build-and-push.yml` to build and push multi-arch images using buildx.
  - Add steps to set up buildx, log in to Docker Hub, and build and push the images.

* **README.md**
  - Add instructions for building and deploying multi-arch images.
  - Update the usage section to include multi-arch support.

